### PR TITLE
feat: add sustainability category

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -103,7 +103,7 @@ interface DApp {
   img?: string;
 }
 
-type Categories = 'all' | 'defi' | 'collectibles' | 'games' | 'marketplaces' | 'utilities';
+type Categories = 'all' | 'defi' | 'collectibles' | 'games' | 'marketplaces' | 'sustainability' | 'utilities';
 
 @Component({
   components: {
@@ -131,6 +131,7 @@ export default class App extends Vue {
     defi: 'Defi',
     games: 'Games',
     marketplaces: 'Market Places',
+    sustainability: 'Sustainability',
     utilities: 'Utilities',
   };
 


### PR DESCRIPTION
## Summary

- Adds `sustainability` to the `Categories` type union in `src/App.vue`
- Registers a `Sustainability` label in the sidebar `menus` so apps tagged with the new category show up in the UI

## Motivation

VeBetterDAO X2Earn apps are increasingly sustainability-focused. The companion PR vechain/app-hub#466 adds `sustainability` as a valid manifest category in the app-hub validator; this PR makes apps.vechain.org render that category correctly instead of dropping the menu entry or showing `undefined` in the sidebar title.

## Test plan

- [ ] `npm run build` succeeds
- [ ] After vechain/app-hub#466 lands and is republished, an app with `"category": "sustainability"` appears under the new sidebar entry and the title reads "Sustainability"

🤖 Generated with [Claude Code](https://claude.com/claude-code)